### PR TITLE
1.1.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: goto-bus-stop/setup-zig@v2
         if: ${{ matrix.settings.target == 'armv7-unknown-linux-gnueabihf' }}
         with:
-          version: 0.10.1
+          version: 0.13.0
       - name: Setup toolchain
         run: ${{ matrix.settings.setup }}
         if: ${{ matrix.settings.setup }}
@@ -106,7 +106,7 @@ jobs:
         if: ${{ !matrix.settings.docker }}
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bindings-${{ matrix.settings.target }}
           path: ${{ env.APP_NAME }}.*.node
@@ -169,7 +169,7 @@ jobs:
         with:
           run_install: true
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bindings-x86_64-unknown-linux-gnu
           path: .
@@ -196,7 +196,7 @@ jobs:
         with:
           run_install: true
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
       - name: Move artifacts

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -137,7 +137,7 @@ jobs:
         with:
           run_install: true
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bindings-${{ matrix.settings.target }}
           path: .

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ napi = { version = "2.16", default-features = false, features = [
 ] }
 napi-derive = "2.16"
 
-anyhow = { version = "1.0", features = ["backtrace"] }
+anyhow = { version = "1.0.95", features = ["backtrace"] }
 
 rdkafka = { version = "0.37", features = [
     "libz-static",
@@ -30,7 +30,7 @@ tracing-subscriber = { version = "0.3", features = ["json"] }
 nanoid = "0.4.0"
 
 [build-dependencies]
-napi-build = "2.1"
+napi-build = "2.1.4"
 
 [profile.release]
 lto = true

--- a/js-binding.d.ts
+++ b/js-binding.d.ts
@@ -92,8 +92,9 @@ export declare class KafkaConsumer {
   pause(): void
   resume(): void
   unsubscribe(): void
+  shutdownConsumer(): Promise<void>
   seek(topic: string, partition: number, offsetModel: OffsetModel, timeout?: number | undefined | null): void
-  recv(): Promise<Message>
+  recv(): Promise<Message | null>
   commit(topic: string, partition: number, offset: number, commit: CommitMode): void
 }
 export declare class KafkaClientConfig {

--- a/js-src/js-binding.d.ts
+++ b/js-src/js-binding.d.ts
@@ -92,8 +92,9 @@ export declare class KafkaConsumer {
   pause(): void
   resume(): void
   unsubscribe(): void
+  shutdownConsumer(): Promise<void>
   seek(topic: string, partition: number, offsetModel: OffsetModel, timeout?: number | undefined | null): void
-  recv(): Promise<Message>
+  recv(): Promise<Message | null>
   commit(topic: string, partition: number, offset: number, commit: CommitMode): void
 }
 export declare class KafkaClientConfig {

--- a/js-src/kafka-client.ts
+++ b/js-src/kafka-client.ts
@@ -12,7 +12,7 @@ export class KafkaClient {
    * @throws {Error} If the configuration is invalid
    */
   constructor(private readonly kafkaConfiguration: KafkaConfiguration) {
-    this.kafkaClientConfig = new KafkaClientConfig(kafkaConfiguration)
+    this.kafkaClientConfig = new KafkaClientConfig(this.kafkaConfiguration)
   }
 
   /**

--- a/js-src/kafka-stream-readable.ts
+++ b/js-src/kafka-stream-readable.ts
@@ -1,6 +1,6 @@
 import { Readable } from 'stream'
 
-import { CommitMode } from '../js-binding'
+import { CommitMode } from './js-binding'
 import { KafkaConsumer, OffsetModel, TopicPartitionConfig } from './js-binding'
 
 /**

--- a/kafka-client.js
+++ b/kafka-client.js
@@ -13,7 +13,7 @@ class KafkaClient {
      */
     constructor(kafkaConfiguration) {
         this.kafkaConfiguration = kafkaConfiguration;
-        this.kafkaClientConfig = new js_binding_js_1.KafkaClientConfig(kafkaConfiguration);
+        this.kafkaClientConfig = new js_binding_js_1.KafkaClientConfig(this.kafkaConfiguration);
     }
     /**
      * Creates a KafkaProducer instance

--- a/kafka-stream-readable.d.ts
+++ b/kafka-stream-readable.d.ts
@@ -1,5 +1,5 @@
 import { Readable } from 'stream';
-import { CommitMode } from '../js-binding';
+import { CommitMode } from './js-binding';
 import { KafkaConsumer, OffsetModel, TopicPartitionConfig } from './js-binding';
 /**
  * KafkaStreamReadable class

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@napi-rs/cli": "^2.18.4",
     "@types/node": "22.10.1",
     "ava": "6.2.0",
-    "dprint": "^0.47.6",
+    "dprint": "^0.48.0",
     "nanoid": "5.0.9",
     "typescript": "5.7.2",
     "copyfiles": "^2.4.1",
@@ -65,5 +65,5 @@
     "version": "napi version",
     "fmt": "dprint fmt"
   },
-  "packageManager": "pnpm@9.14.2"
+  "packageManager": "pnpm@9.15.1"
 }

--- a/package.json
+++ b/package.json
@@ -65,5 +65,5 @@
     "version": "napi version",
     "fmt": "dprint fmt"
   },
-  "packageManager": "pnpm@9.15.1"
+  "packageManager": "pnpm@9.15.2"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^2.4.1
         version: 2.4.1
       dprint:
-        specifier: ^0.47.6
-        version: 0.47.6
+        specifier: ^0.48.0
+        version: 0.48.0
       nanoid:
         specifier: 5.0.9
         version: 5.0.9
@@ -41,48 +41,48 @@ importers:
 
 packages:
 
-  '@dprint/darwin-arm64@0.47.6':
-    resolution: {integrity: sha512-DrtKVOH7Ue6QYsqsUfUwBlTkSZNF2j35xqyI6KimUT1ulgUPocLG53JC/Aej9KuSCPmt4M3J40xxPKRgIM4jPA==}
+  '@dprint/darwin-arm64@0.48.0':
+    resolution: {integrity: sha512-LJ+02WB1PDIUqobfwxBVMz0cUByXsZ6izFTC9tHR+BDt+qWfoZpCn5r/zpAVSkVlA5LzGHKLVNJrwKwaTnAiVA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@dprint/darwin-x64@0.47.6':
-    resolution: {integrity: sha512-p16a4lMbAo4RngbNTAmtREnIRI/cOcZFy5wHPIzbCDnnHI+4UyHiAypTrpF8U8EYx1tw3hgih2MyAuupa9Gfag==}
+  '@dprint/darwin-x64@0.48.0':
+    resolution: {integrity: sha512-OxfLbitoNvFMVucauJ2DvEaJpnxyyhXWC2M56f2AX8lkZSsHrdMHtklqxHz3cBGVPpcCXjLPRC139ynwmqtjIA==}
     cpu: [x64]
     os: [darwin]
 
-  '@dprint/linux-arm64-glibc@0.47.6':
-    resolution: {integrity: sha512-WHphnk0oXpNzwJ9cjbddOL+hEZkXTvHxcA2pM1h1kWCBa5m+4qh0fg8YCktckMfHx1qdQuZYWRoT4l7yQbzWYA==}
+  '@dprint/linux-arm64-glibc@0.48.0':
+    resolution: {integrity: sha512-VMeyorjMXE9NrksmyOJ0zJRGxT7r7kDBBxshCxW+U1xgW+FqR8oE25RZaeDZZPDzUHapAly4ILZqjExLzAWVpw==}
     cpu: [arm64]
     os: [linux]
 
-  '@dprint/linux-arm64-musl@0.47.6':
-    resolution: {integrity: sha512-/2cSPudajg8J0U69ldNZkJx5QiKZNh+ohNVM9leWZ8v6GXN6sJDHX3T6hzS3ohIb03YOCiLOrJZDy9j3+fSgdQ==}
+  '@dprint/linux-arm64-musl@0.48.0':
+    resolution: {integrity: sha512-1BUHQKEngrZv8F6wq2SVxdokyeUoHFXjz0xbYGwctlFPzXAVNLpDy9FROXsfIKmxZ0NsRqEpatETLmubtvWtcA==}
     cpu: [arm64]
     os: [linux]
 
-  '@dprint/linux-riscv64-glibc@0.47.6':
-    resolution: {integrity: sha512-RMHJ3Zuzpls426upHlAveVwlGMi8oBLzhiCauyC/yWQl3CkGTAYdyhEpGnux0+RxacysfIL2bd8ourx4K0Sx3w==}
+  '@dprint/linux-riscv64-glibc@0.48.0':
+    resolution: {integrity: sha512-c8LktisPGbygyFf9wUg0trbAQDApawU017iPQXkZnGcV4QoCeGkFjnY8vltIKyy5DeP5gIp12KjlaT/wogMPkw==}
     cpu: [riscv64]
     os: [linux]
 
-  '@dprint/linux-x64-glibc@0.47.6':
-    resolution: {integrity: sha512-4zbVsx/a8lHkRyAjfW0PNlN5IMwOJfFapgXNYJowWNO7X3j3m1jYJWovjmdZls+d6pDeOHoanMWtq95wd7zTeQ==}
+  '@dprint/linux-x64-glibc@0.48.0':
+    resolution: {integrity: sha512-Am8rp4FqmkO4aFdmwxk+82g2csxPLTPIlNq0Fa9AZReU15yta3Pq0Pg4AXFq+KSso5L4WGmt09ciCitK5gmdOg==}
     cpu: [x64]
     os: [linux]
 
-  '@dprint/linux-x64-musl@0.47.6':
-    resolution: {integrity: sha512-0C13t4OVzomgQjvUyD5IrRyjLDhGuOtqMo00uJlwn3QHucfgOBqkjyQ5fq7T6+grBse0m14/EWblvSbYkZpyDw==}
+  '@dprint/linux-x64-musl@0.48.0':
+    resolution: {integrity: sha512-0nzrZXOvblM/H4GVffNJ7YZn/Y4F/i+DNDZRT1hQmKuTQurB7a2MBJ91OpooLIWJoSn4q40crwM1Po4xnNXrdg==}
     cpu: [x64]
     os: [linux]
 
-  '@dprint/win32-arm64@0.47.6':
-    resolution: {integrity: sha512-UOkeFMBdGIuGNwfkrJdVM9eNiRMdbZRRGVy0Cdo2AXn/FCDVqZ74KJkvYVcoUE27GCytHi4Sp1s4at7659WCOw==}
+  '@dprint/win32-arm64@0.48.0':
+    resolution: {integrity: sha512-bRcGLbhKEXmP7iXDir/vU6DqkA3XaMqBM6P2ACCJMHd+XKWsz3VJzZMn5hFWZ+oZpxUsS3Mg2RcgH5xVjaawgA==}
     cpu: [arm64]
     os: [win32]
 
-  '@dprint/win32-x64@0.47.6':
-    resolution: {integrity: sha512-i9xwXR8V8Jk/wU1gsYKx15eb0ypBRbRZFkHsnHfC0ZBimcfEOibGnGcfv+UCUcumXtnV46TnBqaJW7H70J1J+A==}
+  '@dprint/win32-x64@0.48.0':
+    resolution: {integrity: sha512-9JOKWWngo5vPBFxJgFogAS4rfFC2GaB9Yew6JZbRBUik7j5Num2muuw5p1tMYnl2NUBdS2W4EgsSLM3uUDyhBQ==}
     cpu: [x64]
     os: [win32]
 
@@ -330,8 +330,8 @@ packages:
     resolution: {integrity: sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==}
     engines: {node: '>=8'}
 
-  dprint@0.47.6:
-    resolution: {integrity: sha512-vCQC+IMHVZbISA5pxEj+yshQbozmQoVFA4lzcLlqJ8rzIAH8U+1DKvesN/2Uv3Bqz6rMW6W4WY7pYJQljmiZ8w==}
+  dprint@0.48.0:
+    resolution: {integrity: sha512-dmCrYTiubcsQklTLUimlO+p8wWgMtZBjpPVsOGiw4kPX7Dn41vwyE1R4qA8Px4xHgQtcX7WP9mJujF4C8vISIw==}
     hasBin: true
 
   eastasianwidth@0.2.0:
@@ -928,31 +928,31 @@ packages:
 
 snapshots:
 
-  '@dprint/darwin-arm64@0.47.6':
+  '@dprint/darwin-arm64@0.48.0':
     optional: true
 
-  '@dprint/darwin-x64@0.47.6':
+  '@dprint/darwin-x64@0.48.0':
     optional: true
 
-  '@dprint/linux-arm64-glibc@0.47.6':
+  '@dprint/linux-arm64-glibc@0.48.0':
     optional: true
 
-  '@dprint/linux-arm64-musl@0.47.6':
+  '@dprint/linux-arm64-musl@0.48.0':
     optional: true
 
-  '@dprint/linux-riscv64-glibc@0.47.6':
+  '@dprint/linux-riscv64-glibc@0.48.0':
     optional: true
 
-  '@dprint/linux-x64-glibc@0.47.6':
+  '@dprint/linux-x64-glibc@0.48.0':
     optional: true
 
-  '@dprint/linux-x64-musl@0.47.6':
+  '@dprint/linux-x64-musl@0.48.0':
     optional: true
 
-  '@dprint/win32-arm64@0.47.6':
+  '@dprint/win32-arm64@0.48.0':
     optional: true
 
-  '@dprint/win32-x64@0.47.6':
+  '@dprint/win32-x64@0.48.0':
     optional: true
 
   '@faker-js/faker@9.3.0': {}
@@ -1238,17 +1238,17 @@ snapshots:
 
   detect-libc@2.0.3: {}
 
-  dprint@0.47.6:
+  dprint@0.48.0:
     optionalDependencies:
-      '@dprint/darwin-arm64': 0.47.6
-      '@dprint/darwin-x64': 0.47.6
-      '@dprint/linux-arm64-glibc': 0.47.6
-      '@dprint/linux-arm64-musl': 0.47.6
-      '@dprint/linux-riscv64-glibc': 0.47.6
-      '@dprint/linux-x64-glibc': 0.47.6
-      '@dprint/linux-x64-musl': 0.47.6
-      '@dprint/win32-arm64': 0.47.6
-      '@dprint/win32-x64': 0.47.6
+      '@dprint/darwin-arm64': 0.48.0
+      '@dprint/darwin-x64': 0.48.0
+      '@dprint/linux-arm64-glibc': 0.48.0
+      '@dprint/linux-arm64-musl': 0.48.0
+      '@dprint/linux-riscv64-glibc': 0.48.0
+      '@dprint/linux-x64-glibc': 0.48.0
+      '@dprint/linux-x64-musl': 0.48.0
+      '@dprint/win32-arm64': 0.48.0
+      '@dprint/win32-x64': 0.48.0
 
   eastasianwidth@0.2.0: {}
 

--- a/src/kafka/consumer/kafka_consumer.rs
+++ b/src/kafka/consumer/kafka_consumer.rs
@@ -185,7 +185,12 @@ impl KafkaConsumer {
 
   #[napi]
   pub async fn shutdown_consumer(&self) -> Result<()> {
-    info!("Shutting down consumer - this will stop the consumer from receiving messages");
+    info!("Shutting down consumer - this will unsubscribe and stop the consumer from receiving messages");
+    
+    // First unsubscribe from topics
+    self.stream_consumer.unsubscribe();
+    
+    // Then send shutdown signal
     let tx = self.shutdown_signal.0.clone();
     tx.send(()).map_err(|e| {
       napi::Error::new(

--- a/src/kafka/consumer/kafka_consumer.rs
+++ b/src/kafka/consumer/kafka_consumer.rs
@@ -186,10 +186,10 @@ impl KafkaConsumer {
   #[napi]
   pub async fn shutdown_consumer(&self) -> Result<()> {
     info!("Shutting down consumer - this will unsubscribe and stop the consumer from receiving messages");
-    
+
     // First unsubscribe from topics
     self.stream_consumer.unsubscribe();
-    
+
     // Then send shutdown signal
     let tx = self.shutdown_signal.0.clone();
     tx.send(()).map_err(|e| {

--- a/src/kafka/consumer/kafka_consumer.rs
+++ b/src/kafka/consumer/kafka_consumer.rs
@@ -1,4 +1,5 @@
 use std::time::Duration;
+use tokio::sync::watch::{self};
 
 use napi::{Either, Result};
 
@@ -27,13 +28,18 @@ use super::{
   },
 };
 
+use tokio::select;
+
 pub const DEFAULT_SEEK_TIMEOUT: i64 = 1500;
+
+type ShutdownSignal = (watch::Sender<()>, watch::Receiver<()>);
 
 #[napi]
 pub struct KafkaConsumer {
   client_config: ClientConfig,
   stream_consumer: StreamConsumer<CustomContext>,
   fecth_metadata_timeout: Duration,
+  shutdown_signal: ShutdownSignal,
 }
 
 #[napi]
@@ -57,6 +63,7 @@ impl KafkaConsumer {
           .fecth_metadata_timeout
           .unwrap_or(DEFAULT_FECTH_METADATA_TIMEOUT.as_millis() as i64) as u64,
       ),
+      shutdown_signal: watch::channel(()),
     })
   }
 
@@ -171,7 +178,22 @@ impl KafkaConsumer {
 
   #[napi]
   pub fn unsubscribe(&self) -> Result<()> {
+    info!("Unsubscribing from topics");
     self.stream_consumer.unsubscribe();
+    Ok(())
+  }
+
+  #[napi]
+  pub async fn shutdown_consumer(&self) -> Result<()> {
+    info!("Shutting down consumer - this will stop the consumer from receiving messages");
+    let tx = self.shutdown_signal.0.clone();
+    tx.send(()).map_err(|e| {
+      napi::Error::new(
+        napi::Status::GenericFailure,
+        format!("Error sending shutdown signal: {:?}", e),
+      )
+    })?;
+
     Ok(())
   }
 
@@ -207,18 +229,24 @@ impl KafkaConsumer {
   }
 
   #[napi]
-  pub async fn recv(&self) -> Result<Message> {
-    self
-      .stream_consumer
-      .recv()
-      .await
-      .map_err(|e| {
-        napi::Error::new(
-          napi::Status::GenericFailure,
-          format!("Error while receiving from stream consumer: {:?}", e),
-        )
-      })
-      .map(|message| create_message(&message, message.payload().unwrap_or(&[])))
+  pub async fn recv(&self) -> Result<Option<Message>> {
+    let mut rx = self.shutdown_signal.1.clone();
+    select! {
+        message = self.stream_consumer.recv() => {
+            message
+                .map_err(|e| {
+                    napi::Error::new(
+                        napi::Status::GenericFailure,
+                        format!("Error while receiving from stream consumer: {:?}", e),
+                    )
+                })
+                .map(|message| Some(create_message(&message, message.payload().unwrap_or(&[]))))
+        }
+        _ = rx.changed() => {
+            info!("Shutdown signal received and this will stop the consumer from receiving messages");
+            Ok(None)
+        }
+    }
   }
 
   #[napi]


### PR DESCRIPTION
# Automatically unsubscribe on shutdown_consumer to ensure cleanup

## Description
This PR enhances the Kafka consumer cleanup process by automatically unsubscribing from topics when shutting down the consumer and changes the return type of `recv()` method in JavaScript.

## Changes
- Added automatic unsubscribe call in `shutdown_consumer` method
- Updated logging messages to be more descriptive about the shutdown process
- Ensure shutdown signal is sent after unsubscribing
- Changed `recv()` method return type to be more TypeScript friendly

## Testing
- [ ] Test consumer shutdown process
- [ ] Verify no hanging connections after shutdown
- [ ] Test resubscribing with a new consumer instance
- [ ] Test recv() method returns null on shutdown
- [ ] Test TypeScript type definitions

## Breaking Changes
Yes. This includes a breaking change in the JavaScript/TypeScript API:

Before:
```typescript
// Old return type
recv(): Promise<Message>
```

After:
```typescript
// New return type
recv(): Promise<Message | null>
```

Consumers will need to update their null checks from:
```typescript
const msg = await consumer.recv();
if (msg === null) {
  // handle no message (after call shutdownConsumer method)
}
```