### PR TITLE
feat: add subscribeAll method for parallel consumer subscription

### DIFF
--- a/packages/kafka-crab-js/js-src/index.ts
+++ b/packages/kafka-crab-js/js-src/index.ts
@@ -29,7 +29,12 @@ export { BaseKafkaStreamReadable } from './streams/base-kafka-stream-readable.js
 export { KafkaBatchStreamReadable } from './streams/kafka-batch-stream-readable.js'
 export { KafkaStreamReadable } from './streams/kafka-stream-readable.js'
 
-export type { KafkaClientConfiguration, StreamConsumerConfiguration } from './kafka-client.js'
+export type {
+  KafkaClientConfiguration,
+  StreamConsumerConfiguration,
+  SubscribeAllItem,
+  SubscribeAllResult,
+} from './kafka-client.js'
 
 // Diagnostic Channels exports
 export {

--- a/packages/kafka-crab-js/js-src/index.ts
+++ b/packages/kafka-crab-js/js-src/index.ts
@@ -33,6 +33,7 @@ export type {
   KafkaClientConfiguration,
   StreamConsumerConfiguration,
   SubscribeAllItem,
+  SubscribeAllOptions,
   SubscribeAllResult,
 } from './kafka-client.js'
 

--- a/packages/kafka-crab-js/js-src/kafka-client.ts
+++ b/packages/kafka-crab-js/js-src/kafka-client.ts
@@ -178,29 +178,6 @@ export class KafkaClient {
    * @param options - Optional configuration for batch processing
    * @param options.batchSize - Number of consumers to subscribe in parallel per batch (default: 5)
    * @returns Promise resolving to array of results with success/error status for each consumer
-   *
-   * @example
-   * ```typescript
-   * const consumer1 = client.createConsumer({ groupId: 'group-1' })
-   * const consumer2 = client.createConsumer({ groupId: 'group-2' })
-   * const consumer3 = client.createConsumer({ groupId: 'group-3' })
-   *
-   * const results = await client.subscribeAll([
-   *   { consumer: consumer1, topics: 'topic-a' },
-   *   { consumer: consumer2, topics: 'topic-b' },
-   *   { consumer: consumer3, topics: [{ topic: 'topic-c', createTopic: true }] },
-   * ])
-   *
-   * // Check results
-   * for (const result of results) {
-   *   if (!result.success) {
-   *     console.error('Failed to subscribe:', result.error)
-   *   }
-   * }
-   *
-   * // With custom batch size
-   * const results = await client.subscribeAll(items, { batchSize: 10 })
-   * ```
    */
   async subscribeAll(items: SubscribeAllItem[], options?: SubscribeAllOptions): Promise<SubscribeAllResult[]> {
     const batchSize = options?.batchSize ?? 5

--- a/packages/kafka-crab-js/js-src/kafka-client.ts
+++ b/packages/kafka-crab-js/js-src/kafka-client.ts
@@ -6,6 +6,7 @@ import {
   type KafkaConsumer,
   type KafkaProducer,
   type ProducerConfiguration,
+  type TopicPartitionConfig,
 } from '../js-binding.js'
 
 import {
@@ -20,6 +21,23 @@ export interface StreamConsumerConfiguration extends ConsumerConfiguration {
   batchSize?: number // Default 1 (single mode), > 1 enables batch mode
   batchTimeout?: number // Default 100ms, only used when batchSize > 1
   streamOptions?: ReadableOptions
+}
+
+/**
+ * Configuration for subscribing a consumer to topics in parallel
+ */
+export interface SubscribeAllItem {
+  consumer: KafkaConsumer
+  topics: string | TopicPartitionConfig[]
+}
+
+/**
+ * Result of a single subscribe operation in subscribeAll
+ */
+export interface SubscribeAllResult {
+  consumer: KafkaConsumer
+  success: boolean
+  error?: Error
 }
 
 export interface KafkaClientConfiguration extends Omit<KafkaConfiguration, 'clientId'> {
@@ -137,6 +155,51 @@ export class KafkaClient {
     }
 
     return new KafkaStreamReadable({ kafkaConsumer: instrumentedConsumer, ...opts })
+  }
+
+  /**
+   * Subscribes multiple consumers to their topics in parallel.
+   * This is useful when you have many consumers to register and want to avoid
+   * sequential timeouts from metadata fetching operations.
+   *
+   * @param items - Array of consumer and topics configurations
+   * @returns Promise resolving to array of results with success/error status for each consumer
+   *
+   * @example
+   * ```typescript
+   * const consumer1 = client.createConsumer({ groupId: 'group-1' })
+   * const consumer2 = client.createConsumer({ groupId: 'group-2' })
+   * const consumer3 = client.createConsumer({ groupId: 'group-3' })
+   *
+   * const results = await client.subscribeAll([
+   *   { consumer: consumer1, topics: 'topic-a' },
+   *   { consumer: consumer2, topics: 'topic-b' },
+   *   { consumer: consumer3, topics: [{ topic: 'topic-c', createTopic: true }] },
+   * ])
+   *
+   * // Check results
+   * for (const result of results) {
+   *   if (!result.success) {
+   *     console.error('Failed to subscribe:', result.error)
+   *   }
+   * }
+   * ```
+   */
+  async subscribeAll(items: SubscribeAllItem[]): Promise<SubscribeAllResult[]> {
+    const promises = items.map(async ({ consumer, topics }): Promise<SubscribeAllResult> => {
+      try {
+        await consumer.subscribe(topics)
+        return { consumer, success: true }
+      } catch (error) {
+        return {
+          consumer,
+          success: false,
+          error: error instanceof Error ? error : new Error(String(error)),
+        }
+      }
+    })
+
+    return Promise.all(promises)
   }
 
   private _instrumentProducer(producer: KafkaProducer) {

--- a/packages/kafka-crab-js/js-src/kafka-client.ts
+++ b/packages/kafka-crab-js/js-src/kafka-client.ts
@@ -40,6 +40,17 @@ export interface SubscribeAllResult {
   error?: Error
 }
 
+/**
+ * Options for subscribeAll method
+ */
+export interface SubscribeAllOptions {
+  /**
+   * Number of consumers to subscribe in parallel per batch.
+   * @default 5
+   */
+  batchSize?: number
+}
+
 export interface KafkaClientConfiguration extends Omit<KafkaConfiguration, 'clientId'> {
   /**
    * Optional client id; defaults to librdkafka's default (`rdkafka`).
@@ -158,11 +169,14 @@ export class KafkaClient {
   }
 
   /**
-   * Subscribes multiple consumers to their topics in parallel.
+   * Subscribes multiple consumers to their topics in parallel batches.
    * This is useful when you have many consumers to register and want to avoid
-   * sequential timeouts from metadata fetching operations.
+   * sequential timeouts from metadata fetching operations while also preventing
+   * overloading the broker with too many concurrent subscriptions.
    *
    * @param items - Array of consumer and topics configurations
+   * @param options - Optional configuration for batch processing
+   * @param options.batchSize - Number of consumers to subscribe in parallel per batch (default: 5)
    * @returns Promise resolving to array of results with success/error status for each consumer
    *
    * @example
@@ -183,23 +197,35 @@ export class KafkaClient {
    *     console.error('Failed to subscribe:', result.error)
    *   }
    * }
+   *
+   * // With custom batch size
+   * const results = await client.subscribeAll(items, { batchSize: 10 })
    * ```
    */
-  async subscribeAll(items: SubscribeAllItem[]): Promise<SubscribeAllResult[]> {
-    const promises = items.map(async ({ consumer, topics }): Promise<SubscribeAllResult> => {
-      try {
-        await consumer.subscribe(topics)
-        return { consumer, success: true }
-      } catch (error) {
-        return {
-          consumer,
-          success: false,
-          error: error instanceof Error ? error : new Error(String(error)),
-        }
-      }
-    })
+  async subscribeAll(items: SubscribeAllItem[], options?: SubscribeAllOptions): Promise<SubscribeAllResult[]> {
+    const batchSize = options?.batchSize ?? 5
+    const results: SubscribeAllResult[] = []
 
-    return Promise.all(promises)
+    for (let i = 0; i < items.length; i += batchSize) {
+      const batch = items.slice(i, i + batchSize)
+      const batchPromises = batch.map(async ({ consumer, topics }): Promise<SubscribeAllResult> => {
+        try {
+          await consumer.subscribe(topics)
+          return { consumer, success: true }
+        } catch (error) {
+          return {
+            consumer,
+            success: false,
+            error: error instanceof Error ? error : new Error(String(error)),
+          }
+        }
+      })
+
+      const batchResults = await Promise.all(batchPromises)
+      results.push(...batchResults)
+    }
+
+    return results
   }
 
   private _instrumentProducer(producer: KafkaProducer) {


### PR DESCRIPTION
 Resumo                                                                                                              
                  
  - Adicionado método subscribeAll no KafkaClient para inscrever múltiplos consumers em seus tópicos em lotes
  paralelos
  - Os consumers são processados em lotes de 5 (configurável via opção batchSize) para evitar sobrecarregar o broker
  com muitas operações concorrentes de metadata fetching
  - Cada falha de inscrição é capturada individualmente sem abortar as inscrições restantes

  Novos tipos

  - SubscribeAllItem - Configuração que associa um consumer aos seus tópicos
  - SubscribeAllResult - Objeto de resultado com status de sucesso/erro por consumer
  - SubscribeAllOptions - Configuração opcional (batchSize)

  Uso

  const results = await client.subscribeAll([
    { consumer: consumer1, topics: 'topic-a' },
    { consumer: consumer2, topics: 'topic-b' },
    { consumer: consumer3, topics: [{ topic: 'topic-c', createTopic: true }] },
  ])

  // Com batch size customizado
  const results = await client.subscribeAll(items, { batchSize: 10 })

  Plano de testes

  - Validar inscrição de múltiplos consumers com batch size padrão
  - Validar opção de batchSize customizado
  - Validar tratamento de erro quando um consumer falha na inscrição
  - Validar comportamento com array de items vazio

  ---